### PR TITLE
docs: add case insensitive match example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ func main() {
 	
 	// Unicode normalized matching.
 	fuzzy.MatchNormalized("cartwheel", "cartwhéél") // true
+
+	// Case insensitive matching.
+	fuzzy.MatchFold("ArTeeL", "cartwheel") // true
 }
 ```
 


### PR DESCRIPTION
Fixes #31 (was a documentation problem, I didn't look at the docs)