### PR TITLE
Reduce the number of allocations on the LevenshteinDistance function

### DIFF
--- a/fuzzy/levenshtein.go
+++ b/fuzzy/levenshtein.go
@@ -10,10 +10,10 @@ package fuzzy
 // http://en.wikibooks.org/wiki/Algorithm_implementation/Strings/Levenshtein_distance#C
 func LevenshteinDistance(s, t string) int {
 	r1, r2 := []rune(s), []rune(t)
-	column := make([]int, len(r1)+1)
+	column := make([]int, 1, 64)
 
 	for y := 1; y <= len(r1); y++ {
-		column[y] = y
+		column = append(column, y)
 	}
 
 	for x := 1; x <= len(r2); x++ {


### PR DESCRIPTION
This PR makes the LevenshteinDistance function a bit faster for small strings, but most importantly reduces the number of allocations by allocating the column slice on the stack
Somehow for bigger strings it also reduced the allocation count by 1, I think the compiler recognizes this pattern of appending in a loop and optimizes it

```
name                            old time/op    new time/op    delta
LevenshteinDistance-16             111ns ± 5%      57ns ± 1%   -48.26%  (p=0.008 n=5+5)
LevenshteinDistanceBigLate-16     12.3µs ± 2%    13.4µs ± 2%    +9.02%  (p=0.008 n=5+5)
LevenshteinDistanceBigEarly-16    11.1µs ± 3%    11.5µs ± 0%    +3.10%  (p=0.016 n=5+4)

name                            old alloc/op   new alloc/op   delta
LevenshteinDistance-16             40.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
LevenshteinDistanceBigLate-16     6.58kB ± 0%    6.53kB ± 0%    -0.73%  (p=0.008 n=5+5)
LevenshteinDistanceBigEarly-16    6.58kB ± 0%    6.53kB ± 0%    -0.73%  (p=0.008 n=5+5)

name                            old allocs/op  new allocs/op  delta
LevenshteinDistance-16              2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
LevenshteinDistanceBigLate-16       2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
LevenshteinDistanceBigEarly-16      2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
```

For strings a bit bigger (but smaller than 64 runes) the speed improvement vanishes but the 0 alocation remains

```
name                    old time/op    new time/op    delta
LevenshteinDistance-16    1.35µs ± 1%    1.31µs ± 2%    -3.20%  (p=0.029 n=4+4)

name                    old alloc/op   new alloc/op   delta
LevenshteinDistance-16      272B ± 0%        0B       -100.00%  (p=0.029 n=4+4)

name                    old allocs/op  new allocs/op  delta
LevenshteinDistance-16      2.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
```
