### PR TITLE
Stringer interface support

### DIFF
--- a/fuzzy/fuzzy_stringer.go
+++ b/fuzzy/fuzzy_stringer.go
@@ -1,0 +1,217 @@
+// Fuzzy searching allows for flexibly matching a string with partial input,
+// useful for filtering data very quickly based on lightweight user input.
+package fuzzy
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"golang.org/x/text/transform"
+)
+
+// MatchStringer returns true if source matches target using a fuzzy-searching
+// algorithm. Note that it doesn't implement Levenshtein distance (see
+// RankMatchStringer instead), but rather a simplified version where there's no
+// approximation. The method will return true only if each character in the
+// source can be found in the target and occurs after the preceding matches.
+// This is the Stringer version of Match.
+func MatchStringer(source string, target fmt.Stringer) bool {
+	return matchStringer(source, target, noopTransformer())
+}
+
+// MatchFoldStringer is a case-insensitive version of MatchStringer.
+func MatchFoldStringer(source string, target fmt.Stringer) bool {
+	return matchStringer(source, target, foldTransformer())
+}
+
+// MatchNormalizedStringer is a unicode-normalized version of MatchStringer.
+func MatchNormalizedStringer(source string, target fmt.Stringer) bool {
+	return matchStringer(source, target, normalizeTransformer())
+}
+
+// MatchNormalizedFoldStringer is a unicode-normalized and case-insensitive version of MatchStringer.
+func MatchNormalizedFoldStringer(source string, target fmt.Stringer) bool {
+	return matchStringer(source, target, normalizedFoldTransformer())
+}
+
+func matchStringer(source string, target1 fmt.Stringer, transformer transform.Transformer) bool {
+	source = stringTransform(source, transformer)
+	target := stringTransform(target1.String(), transformer)
+
+	lenDiff := len(target) - len(source)
+
+	if lenDiff < 0 {
+		return false
+	}
+
+	if lenDiff == 0 && source == target {
+		return true
+	}
+
+Outer:
+	for _, r1 := range source {
+		for i, r2 := range target {
+			if r1 == r2 {
+				target = target[i+utf8.RuneLen(r2):]
+				continue Outer
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
+// FindStringer will return a list of strings in targets that fuzzy matches source.
+func FindStringer(source string, targets []fmt.Stringer) []fmt.Stringer {
+	return findStringer(source, targets, noopTransformer())
+}
+
+// FindFoldStringer is a case-insensitive version of FindStringer.
+func FindFoldStringer(source string, targets []fmt.Stringer) []fmt.Stringer {
+	return findStringer(source, targets, foldTransformer())
+}
+
+// FindNormalizedStringer is a unicode-normalized version of FindStringer.
+func FindNormalizedStringer(source string, targets []fmt.Stringer) []fmt.Stringer {
+	return findStringer(source, targets, normalizeTransformer())
+}
+
+// FindNormalizedFoldStringer is a unicode-normalized and case-insensitive version of FindStringer.
+func FindNormalizedFoldStringer(source string, targets []fmt.Stringer) []fmt.Stringer {
+	return findStringer(source, targets, normalizedFoldTransformer())
+}
+
+func findStringer(source string, targets []fmt.Stringer, transformer transform.Transformer) []fmt.Stringer {
+	var matches []fmt.Stringer
+
+	for _, target := range targets {
+		if matchStringer(source, target, transformer) {
+			matches = append(matches, target)
+		}
+	}
+
+	return matches
+}
+
+// RankMatchStringer is similar to MatchStringer except it will measure the Levenshtein
+// distance between the source and the target and return its result. If there
+// was no matchStringer, it will return -1.
+// Given the requirements of matchStringer, RankMatchStringer only needs to perform a subset of
+// the Levenshtein calculation, only deletions need be considered, required
+// additions and substitutions would fail the matchStringer test.
+// This is the Stringer version of RankMatch.
+func RankMatchStringer(source string, target fmt.Stringer) int {
+	return rankStringer(source, target, noopTransformer())
+}
+
+// RankMatchFoldStringer is a case-insensitive version of RankMatchStringer.
+func RankMatchFoldStringer(source string, target fmt.Stringer) int {
+	return rankStringer(source, target, foldTransformer())
+}
+
+// RankMatchNormalizedStringer is a unicode-normalized version of RankMatchStringer.
+func RankMatchNormalizedStringer(source string, target fmt.Stringer) int {
+	return rankStringer(source, target, normalizeTransformer())
+}
+
+// RankMatchNormalizedFoldStringer is a unicode-normalized and case-insensitive version of RankMatchStringer.
+func RankMatchNormalizedFoldStringer(source string, target fmt.Stringer) int {
+	return rankStringer(source, target, normalizedFoldTransformer())
+}
+
+func rankStringer(source string, target1 fmt.Stringer, transformer transform.Transformer) int {
+	lenDiff := len(target1.String()) - len(source)
+
+	if lenDiff < 0 {
+		return -1
+	}
+
+	source = stringTransform(source, transformer)
+	target := stringTransform(target1.String(), transformer)
+
+	if lenDiff == 0 && source == target {
+		return 0
+	}
+
+	runeDiff := 0
+
+Outer:
+	for _, r1 := range source {
+		for i, r2 := range target {
+			if r1 == r2 {
+				target = target[i+utf8.RuneLen(r2):]
+				continue Outer
+			} else {
+				runeDiff++
+			}
+		}
+		return -1
+	}
+
+	// Count up remaining char
+	runeDiff += utf8.RuneCountInString(target)
+
+	return runeDiff
+}
+
+// RankFindStringer is similar to FindStringer, except it will also rankStringer all matches using
+// Levenshtein distance.
+func RankFindStringer(source string, targets []fmt.Stringer) RanksStringer {
+	return rankFindStringer(source, targets, noopTransformer())
+}
+
+// RankFindFoldStringer is a case-insensitive version of RankFindStringer.
+func RankFindFoldStringer(source string, targets []fmt.Stringer) RanksStringer {
+	return rankFindStringer(source, targets, foldTransformer())
+}
+
+// RankFindNormalizedStringer is a unicode-normalized version of RankFindStringer.
+func RankFindNormalizedStringer(source string, targets []fmt.Stringer) RanksStringer {
+	return rankFindStringer(source, targets, normalizeTransformer())
+}
+
+// RankFindNormalizedFoldStringer is a unicode-normalized and case-insensitive version of RankFindStringer.
+func RankFindNormalizedFoldStringer(source string, targets []fmt.Stringer) RanksStringer {
+	return rankFindStringer(source, targets, normalizedFoldTransformer())
+}
+
+func rankFindStringer(source string, targets []fmt.Stringer, transformer transform.Transformer) RanksStringer {
+	var r RanksStringer
+
+	for index, target := range targets {
+		if matchStringer(source, target, transformer) {
+			distance := LevenshteinDistance(source, target.String())
+			r = append(r, RankStringer{source, target, distance, index})
+		}
+	}
+	return r
+}
+
+type RankStringer struct {
+	// Source is used as the source for matching.
+	Source string
+
+	// Target is the word matched against.
+	Target fmt.Stringer
+
+	// Distance is the Levenshtein distance between Source and Target.
+	Distance int
+
+	// Location of Target in original list
+	OriginalIndex int
+}
+
+type RanksStringer []RankStringer
+
+func (r RanksStringer) Len() int {
+	return len(r)
+}
+
+func (r RanksStringer) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r RanksStringer) Less(i, j int) bool {
+	return r[i].Distance < r[j].Distance
+}

--- a/fuzzy/fuzzy_stringer_test.go
+++ b/fuzzy/fuzzy_stringer_test.go
@@ -1,0 +1,391 @@
+package fuzzy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type stringer struct {
+	string
+}
+
+func (s stringer) String() string {
+	return s.string
+}
+
+var fuzzyTestsStringer = []struct {
+	source string
+	target fmt.Stringer
+	wanted bool
+	rank   int
+}{
+	{"zazz", stringer{deBelloGallico + " zazz"}, true, 1544},
+	{"zazz", stringer{"zazz " + deBelloGallico}, true, 1544},
+	{"twl", stringer{"cartwheel"}, true, 6},
+	{"cart", stringer{"cartwheel"}, true, 5},
+	{"cw", stringer{"cartwheel"}, true, 7},
+	{"ee", stringer{"cartwheel"}, true, 7},
+	{"art", stringer{"cartwheel"}, true, 6},
+	{"eeel", stringer{"cartwheel"}, false, -1},
+	{"dog", stringer{"cartwheel"}, false, -1},
+	{"ёлка", stringer{"ёлочка"}, true, 2},
+	{"ветер", stringer{"ёлочка"}, false, -1},
+	{"中国", stringer{"中华人民共和国"}, true, 5},
+	{"日本", stringer{"中华人民共和国"}, false, -1},
+	{"イ", stringer{"イカ"}, true, 1},
+	{"limón", stringer{"limon"}, false, -1},
+	{"kitten", stringer{"setting"}, false, -1},
+}
+
+func TestFuzzyMatchStringer(t *testing.T) {
+	for _, val := range fuzzyTestsStringer {
+		match := MatchStringer(val.source, val.target)
+		if match != val.wanted {
+			t.Errorf("%s in %s expected matchStringer to be %t, got %t",
+				val.source, val.target, val.wanted, match)
+		}
+	}
+}
+
+func TestFuzzyMatchFoldStringer(t *testing.T) {
+	for _, val := range fuzzyTestsStringer {
+		match := MatchFoldStringer(val.source, stringer{strings.ToUpper(val.target.String())})
+		if match != val.wanted {
+			t.Errorf("%s in %s expected matchStringer to be %t, got %t",
+				val.source, strings.ToUpper(val.target.String()), val.wanted, match)
+		}
+	}
+}
+
+func TestFuzzyMatchNormalizedStringer(t *testing.T) {
+	var normalizedTests = []struct {
+		source string
+		target fmt.Stringer
+		wanted bool
+	}{
+		{"limon", stringer{"limón"}, true},
+		{"limón", stringer{"limon tart"}, true},
+		{"limón", stringer{"LiMóN tArT"}, false},
+		{"limón", stringer{"LeMoN tArT"}, false},
+	}
+
+	for _, val := range normalizedTests {
+		match := MatchNormalizedStringer(val.source, val.target)
+		if match != val.wanted {
+			t.Errorf("%s in %s expected matchStringer to be %t, got %t",
+				val.source, val.target, val.wanted, match)
+		}
+	}
+}
+
+func TestFuzzyMatchNormalizedFoldStringer(t *testing.T) {
+	var normalizedTests = []struct {
+		source string
+		target fmt.Stringer
+		wanted bool
+	}{
+		{"limon", stringer{"limón"}, true},
+		{"limón", stringer{"limon tart"}, true},
+		{"limón", stringer{"LiMóN tArT"}, true},
+		{"limón", stringer{"LeMoN tArT"}, false},
+	}
+
+	for _, val := range normalizedTests {
+		match := MatchNormalizedFoldStringer(val.source, val.target)
+		if match != val.wanted {
+			t.Errorf("%s in %s expected matchStringer to be %t, got %t",
+				val.source, val.target, val.wanted, match)
+		}
+	}
+}
+
+func TestFuzzyFindStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}, stringer{"cartwhéél"}}
+	wanted := []string{"cartwheel", "wheel"}
+
+	matches := FindStringer("whel", target)
+
+	if len(matches) != len(wanted) {
+		t.Errorf("expected %s, got %s", wanted, matches)
+	}
+
+	for i := range wanted {
+		if wanted[i] != matches[i].String() {
+			t.Errorf("expected %s, got %s", wanted, matches)
+		}
+	}
+}
+
+func TestFuzzyFindNormalizedStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}, stringer{"cartwhéél"}, stringer{"WHEEL"}}
+	wanted := []string{"cartwheel", "wheel", "cartwhéél"}
+
+	matches := FindNormalizedStringer("whél", target)
+
+	if len(matches) != len(wanted) {
+		t.Errorf("expected %s, got %s", wanted, matches)
+	}
+
+	for i := range wanted {
+		if wanted[i] != matches[i].String() {
+			t.Errorf("expected %s, got %s", wanted, matches)
+		}
+	}
+}
+
+func TestFuzzyFindNormalizedFoldStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}, stringer{"cartwhéél"}, stringer{"WHEEL"}}
+	wanted := []string{"cartwheel", "wheel", "cartwhéél", "WHEEL"}
+
+	matches := FindNormalizedFoldStringer("whél", target)
+
+	if len(matches) != len(wanted) {
+		t.Errorf("expected %s, got %s", wanted, matches)
+	}
+
+	for i := range wanted {
+		if wanted[i] != matches[i].String() {
+			t.Errorf("expected %s, got %s", wanted, matches)
+		}
+	}
+}
+
+func TestRankMatchStringer(t *testing.T) {
+	for _, val := range fuzzyTestsStringer {
+		rank := RankMatchStringer(val.source, val.target)
+		if rank != val.rank {
+			t.Errorf("expected ranking %d, got %d for %s in %s",
+				val.rank, rank, val.source, val.target)
+		}
+	}
+}
+
+func TestRankMatchNormalizedStringer(t *testing.T) {
+	var fuzzyTests = []struct {
+		source string
+		target fmt.Stringer
+		rank   int
+	}{
+		{"limó", stringer{"limon"}, 1},
+		{"limó", stringer{"limon"}, 1},
+		{"limó", stringer{"LIMON"}, -1},
+	}
+
+	for _, val := range fuzzyTests {
+		rank := RankMatchNormalizedStringer(val.source, val.target)
+		if rank != val.rank {
+			t.Errorf("expected ranking %d, got %d for %s in %s",
+				val.rank, rank, val.source, val.target)
+		}
+	}
+}
+
+func TestRankMatchNormalizedFoldStringer(t *testing.T) {
+	var fuzzyTests = []struct {
+		source string
+		target fmt.Stringer
+		rank   int
+	}{
+		{"limó", stringer{"limon"}, 1},
+		{"limó", stringer{"limon"}, 1},
+		{"limó", stringer{"LIMON"}, 1},
+		{"limó", stringer{"LIMON TART"}, 6},
+	}
+
+	for _, val := range fuzzyTests {
+		rank := RankMatchNormalizedFoldStringer(val.source, val.target)
+		if rank != val.rank {
+			t.Errorf("expected ranking %d, got %d for %s in %s",
+				val.rank, rank, val.source, val.target)
+		}
+	}
+}
+
+func TestRankMatchNormalizedFoldStringerConcurrent(t *testing.T) {
+	var target []fmt.Stringer
+	for _, s := range strings.Split("Lorem ipsum dolor sit amet, consectetur adipiscing elit", " ") {
+		target = append(target, stringer{s})
+	}
+	source := "ips"
+	procs := 10
+	iter := 10
+	type empty struct{}
+	done := make(chan empty)
+	for i := 0; i <= procs; i++ {
+		go func() {
+			for n := 0; n < iter; n++ {
+				_ = RankFindNormalizedFoldStringer(source, target)
+			}
+			done <- empty{}
+		}()
+	}
+	cnt := 0
+	for i := 0; i < procs; i++ {
+		<-done
+		cnt++
+	}
+}
+
+func TestRankFindStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}}
+	wanted := []RankStringer{
+		{"whl", stringer{"cartwheel"}, 6, 0},
+		{"whl", stringer{"wheel"}, 2, 2},
+	}
+
+	ranks := RankFindStringer("whl", target)
+
+	if len(ranks) != len(wanted) {
+		t.Errorf("expected %+v, got %+v", wanted, ranks)
+	}
+
+	for i := range wanted {
+		if wanted[i] != ranks[i] {
+			t.Errorf("expected %+v, got %+v", wanted, ranks)
+		}
+	}
+}
+
+func TestRankFindNormalizedStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"limón"}, stringer{"limon"}, stringer{"lemon"}, stringer{"LIMON"}}
+	wanted := []RankStringer{
+		{"limó", stringer{"limón"}, 1, 0},
+		{"limó", stringer{"limon"}, 2, 1},
+	}
+
+	ranks := RankFindNormalizedStringer("limó", target)
+
+	if len(ranks) != len(wanted) {
+		t.Errorf("expected %+v, got %+v", wanted, ranks)
+	}
+
+	for i := range wanted {
+		if wanted[i] != ranks[i] {
+			t.Errorf("expected %+v, got %+v", wanted, ranks)
+		}
+	}
+}
+
+func TestRankFindNormalizedFoldStringer(t *testing.T) {
+	target := []fmt.Stringer{stringer{"limón"}, stringer{"limon"}, stringer{"lemon"}, stringer{"LIMON"}}
+	wanted := []RankStringer{
+		{"limó", stringer{"limón"}, 1, 0},
+		{"limó", stringer{"limon"}, 2, 1},
+		{"limó", stringer{"LIMON"}, 5, 3},
+	}
+
+	ranks := RankFindNormalizedFoldStringer("limó", target)
+
+	if len(ranks) != len(wanted) {
+		t.Errorf("expected %+v, got %+v", wanted, ranks)
+	}
+
+	for i := range wanted {
+		if wanted[i] != ranks[i] {
+			t.Errorf("expected %+v, got %+v", wanted, ranks)
+		}
+	}
+}
+
+func TestSortingRanksStringer(t *testing.T) {
+	rs := RanksStringer{{"a", stringer{"b"}, 1, 0}, {"a", stringer{"cc"}, 2, 1}, {"a", stringer{"a"}, 0, 2}}
+	wanted := RanksStringer{rs[2], rs[0], rs[1]}
+
+	sort.Sort(rs)
+
+	for i := range wanted {
+		if wanted[i] != rs[i] {
+			t.Errorf("expected %+v, got %+v", wanted, rs)
+		}
+	}
+}
+
+func BenchmarkMatchStringer(b *testing.B) {
+	ft := fuzzyTestsStringer[2]
+	for i := 0; i < b.N; i++ {
+		MatchStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkMatchStringerBigLate(b *testing.B) {
+	ft := fuzzyTestsStringer[0]
+	for i := 0; i < b.N; i++ {
+		MatchStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkMatchStringerBigEarly(b *testing.B) {
+	ft := fuzzyTestsStringer[1]
+	for i := 0; i < b.N; i++ {
+		MatchStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkMatchFoldStringer(b *testing.B) {
+	ft := fuzzyTestsStringer[2]
+	for i := 0; i < b.N; i++ {
+		MatchFoldStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkMatchFoldStringerBigLate(b *testing.B) {
+	ft := fuzzyTestsStringer[0]
+	for i := 0; i < b.N; i++ {
+		MatchFoldStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkMatchFoldStringerBigEarly(b *testing.B) {
+	ft := fuzzyTestsStringer[1]
+	for i := 0; i < b.N; i++ {
+		MatchFoldStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkRankMatchStringer(b *testing.B) {
+	ft := fuzzyTestsStringer[2]
+	for i := 0; i < b.N; i++ {
+		RankMatchStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkRankMatchStringerBigLate(b *testing.B) {
+	ft := fuzzyTestsStringer[0]
+	for i := 0; i < b.N; i++ {
+		RankMatchStringer(ft.source, ft.target)
+	}
+}
+
+func BenchmarkRankMatchStringerBigEarly(b *testing.B) {
+	ft := fuzzyTestsStringer[1]
+	for i := 0; i < b.N; i++ {
+		RankMatchStringer(ft.source, ft.target)
+	}
+}
+
+func ExampleMatchStringer() {
+	fmt.Print(MatchStringer("twl", stringer{
+		"cartwheel",
+	}))
+	// Output: true
+}
+
+func ExampleFindStringer() {
+	fmt.Print(FindStringer("whl", []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}}))
+	// Output: [cartwheel wheel]
+}
+
+func ExampleRankMatchStringer() {
+	fmt.Print(RankMatchStringer("twl",
+		stringer{
+			"cartwheel",
+		}))
+	// Output: 6
+}
+
+func ExampleRankFindStringer() {
+	fmt.Printf("%+v", RankFindStringer("whl", []fmt.Stringer{stringer{"cartwheel"}, stringer{"foobar"}, stringer{"wheel"}, stringer{"baz"}}))
+	// Output: [{Source:whl Target:cartwheel Distance:6 OriginalIndex:0} {Source:whl Target:wheel Distance:2 OriginalIndex:2}]
+}

--- a/fuzzy/levenshtein.go
+++ b/fuzzy/levenshtein.go
@@ -1,5 +1,7 @@
 package fuzzy
 
+import "fmt"
+
 // LevenshteinDistance measures the difference between two strings.
 // The Levenshtein distance between two words is the minimum number of
 // single-character edits (i.e. insertions, deletions or substitutions)
@@ -32,7 +34,9 @@ func LevenshteinDistance(s, t string) int {
 
 	return column[len(r1)]
 }
-
+func LevenshteinDistanceStringer(s, t fmt.Stringer) int {
+	return LevenshteinDistance(s.String(), t.String())
+}
 func min(a, b, c int) int {
 	if a < b && a < c {
 		return a


### PR DESCRIPTION
Adds a separate variant set of functions that can optionally be used to consume `Stringer` instead of just `string`

As it does not change the original function set, backwards compatibility is maintained

Addresses #19 