### PR TITLE
fix unicodeFoldTransformer byte consumed counts

### DIFF
--- a/fuzzy/fuzzy_test.go
+++ b/fuzzy/fuzzy_test.go
@@ -47,6 +47,8 @@ var fuzzyTests = []struct {
 	{"イ", "イカ", true, 1},
 	{"limón", "limon", false, -1},
 	{"kitten", "setting", false, -1},
+	{"\xffinvalid UTF-8\xff", "", false, -1}, // invalid UTF-8
+	{"Ⱦ", "", false, -1},                     // uppercase and lowercase runes have different UTF-8 encoding lengths
 }
 
 func TestFuzzyMatch(t *testing.T) {


### PR DESCRIPTION
This costs some CPU time, but of course it's better than panicking.

Fixes #54

```
goos: darwin
goarch: arm64
pkg: github.com/lithammer/fuzzysearch/fuzzy
                              │      a      │                 b                  │
                              │   sec/op    │   sec/op     vs base               │
Match-8                         16.08n ± 2%   15.99n ± 1%       ~ (p=0.361 n=10)
MatchBigLate-8                  1.005µ ± 1%   1.005µ ± 0%       ~ (p=0.861 n=10)
MatchBigEarly-8                 12.60n ± 1%   12.56n ± 1%       ~ (p=0.641 n=10)
MatchFold-8                     136.0n ± 1%   144.5n ± 1%  +6.25% (p=0.000 n=10)
MatchFoldBigLate-8              7.071µ ± 5%   7.520µ ± 1%  +6.36% (p=0.000 n=10)
MatchFoldBigEarly-8             6.093µ ± 2%   6.560µ ± 3%  +7.67% (p=0.000 n=10)
RankMatch-8                     17.67n ± 1%   17.56n ± 1%       ~ (p=0.319 n=10)
RankMatchBigLate-8              1.008µ ± 2%   1.008µ ± 1%       ~ (p=0.870 n=10)
RankMatchBigEarly-8             1.228µ ± 1%   1.228µ ± 2%       ~ (p=0.821 n=10)
LevenshteinDistance-8           55.63n ± 1%   55.45n ± 2%       ~ (p=0.225 n=10)
LevenshteinDistanceBigLate-8    20.44µ ± 2%   20.44µ ± 3%       ~ (p=0.739 n=10)
LevenshteinDistanceBigEarly-8   20.47µ ± 3%   20.43µ ± 1%       ~ (p=0.280 n=10)
geomean                         539.4n        547.4n       +1.48%
```