### PR TITLE
Create .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+### Go ###
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+


### PR DESCRIPTION
I ran test coverage to this project and notice the `coverage.out` file was available to commit.

With this in mind, this pull request adds a `.gitignore` file to the project, which was previously missing.